### PR TITLE
Improve layout of intro screen and difficulty selector on narrow screens

### DIFF
--- a/src/element-decoder/app.css
+++ b/src/element-decoder/app.css
@@ -5,10 +5,15 @@
   justify-content: center;
   justify-items: center;
   gap: 1em;
+  padding: 2em;
 }
 
 .game-intro > * {
   margin: 0;
+}
+
+.game-intro > h1 {
+  text-align: center;
 }
 
 .game-intro p {
@@ -31,9 +36,6 @@
   font-family: inherit;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  align-content: center;
-  justify-content: center;
-  justify-items: center;
   gap: 1em;
   background-color: white;
   padding: 2em;
@@ -46,6 +48,17 @@
 
 .difficulty-chooser-text {
   grid-column: 1 / span 3;
+  justify-self: center;
   grid-row: 1;
   font-family: inherit;
+}
+
+@media screen and (max-width: 600px) {
+  .difficulty-chooser {
+    grid-template-columns: 1fr;
+  }
+
+  .difficulty-chooser-text {
+    grid-column: 1;
+  }
 }

--- a/src/element-decoder/app.tsx
+++ b/src/element-decoder/app.tsx
@@ -83,7 +83,6 @@ export function App() {
     setSelectedLevel(level);
     setShowLevel(false);
   };
-  console.log("do we show level?:", showLevel);
   return (
     <>
       <ThemeToggle />


### PR DESCRIPTION
# Overview/Screenshots

## Before this PR:

<img width="300" src="https://github.com/Hewitt-Learning/Hewitt-Chemistry-Games/assets/13206945/a36a39c6-b704-4d7a-bfd0-88595fbc006a" />
<img width="300" src="https://github.com/Hewitt-Learning/Hewitt-Chemistry-Games/assets/13206945/e3f717cf-3850-4076-be54-085641d902cd"/>


## In this PR:

Intro screen:

<img width="300" src="https://github.com/Hewitt-Learning/Hewitt-Chemistry-Games/assets/13206945/0763427a-d737-40f2-843f-6d77eb5c7b25" />

<img width="300" src="https://github.com/Hewitt-Learning/Hewitt-Chemistry-Games/assets/13206945/1d58f0ff-b452-442a-8a3b-2b98afbc7e40" />

The intro screen has more even space around it, and the difficulty buttons now use a vertical layout for small screens (and maintain a horizontal layout for larger screns)


# Testing

Netlify created a preview of this merge request [here](https://deploy-preview-1--hewitt-chemistry-games.netlify.app/element-decoder/). You can test these changes by testing out the intro/difficulty chooser on small screens using that URL.

Alternatively, you can test it locally by cloning the repo, checking out the branch, and following the [installation](https://github.com/Hewitt-Learning/Hewitt-Chemistry-Games#installationsetup) and [running](https://github.com/Hewitt-Learning/Hewitt-Chemistry-Games#running-the-project) instructions.